### PR TITLE
Removed assigned variables throwing warnings in Unity.

### DIFF
--- a/Assets/TriangleDotNet/Triangle/NewLocation.cs
+++ b/Assets/TriangleDotNet/Triangle/NewLocation.cs
@@ -78,7 +78,7 @@ namespace TriangleNet
 
             ////////////////////////////// HALE'S VARIABLES //////////////////////////////
             // keeps the difference of coordinates edge 
-            float xShortestEdge = 0, yShortestEdge = 0, xMiddleEdge, yMiddleEdge, xLongestEdge, yLongestEdge;
+            float xShortestEdge, yShortestEdge;
 
             // keeps the square of edge lengths
             float shortestEdgeDist = 0, middleEdgeDist = 0, longestEdgeDist = 0;
@@ -195,8 +195,6 @@ namespace TriangleNet
                     /// smallest angle corner: dest
                     /// largest angle corner: apex
                     xShortestEdge = xao; yShortestEdge = yao;
-                    xMiddleEdge = xda; yMiddleEdge = yda;
-                    xLongestEdge = xdo; yLongestEdge = ydo;
 
                     shortestEdgeDist = aodist;
                     middleEdgeDist = dadist;
@@ -211,8 +209,6 @@ namespace TriangleNet
                     /// smallest angle corner: dest
                     /// largest angle corner: org
                     xShortestEdge = xao; yShortestEdge = yao;
-                    xMiddleEdge = xdo; yMiddleEdge = ydo;
-                    xLongestEdge = xda; yLongestEdge = yda;
 
                     shortestEdgeDist = aodist;
                     middleEdgeDist = dodist;
@@ -227,8 +223,6 @@ namespace TriangleNet
                     /// smallest angle corner: org
                     /// largest angle corner: apex
                     xShortestEdge = xda; yShortestEdge = yda;
-                    xMiddleEdge = xao; yMiddleEdge = yao;
-                    xLongestEdge = xdo; yLongestEdge = ydo;
 
                     shortestEdgeDist = dadist;
                     middleEdgeDist = aodist;
@@ -242,8 +236,6 @@ namespace TriangleNet
                     /// smallest angle corner: org
                     /// largest angle corner: dest
                     xShortestEdge = xda; yShortestEdge = yda;
-                    xMiddleEdge = xdo; yMiddleEdge = ydo;
-                    xLongestEdge = xao; yLongestEdge = yao;
 
                     shortestEdgeDist = dadist;
                     middleEdgeDist = dodist;
@@ -257,8 +249,6 @@ namespace TriangleNet
                     /// smallest angle corner: apex
                     /// largest angle corner: org
                     xShortestEdge = xdo; yShortestEdge = ydo;
-                    xMiddleEdge = xao; yMiddleEdge = yao;
-                    xLongestEdge = xda; yLongestEdge = yda;
 
                     shortestEdgeDist = dodist;
                     middleEdgeDist = aodist;
@@ -273,8 +263,6 @@ namespace TriangleNet
                     /// smallest angle corner: apex
                     /// largest angle corner: dest
                     xShortestEdge = xdo; yShortestEdge = ydo;
-                    xMiddleEdge = xda; yMiddleEdge = yda;
-                    xLongestEdge = xao; yLongestEdge = yao;
 
                     shortestEdgeDist = dodist;
                     middleEdgeDist = dadist;
@@ -778,7 +766,7 @@ namespace TriangleNet
 
             ////////////////////////////// HALE'S VARIABLES //////////////////////////////
             // keeps the difference of coordinates edge 
-            float xShortestEdge = 0, yShortestEdge = 0, xMiddleEdge, yMiddleEdge, xLongestEdge, yLongestEdge;
+            float xShortestEdge = 0, yShortestEdge = 0;
 
             // keeps the square of edge lengths
             float shortestEdgeDist = 0, middleEdgeDist = 0, longestEdgeDist = 0;
@@ -908,8 +896,6 @@ namespace TriangleNet
                     /// smallest angle corner: dest
                     /// largest angle corner: apex
                     xShortestEdge = xao; yShortestEdge = yao;
-                    xMiddleEdge = xda; yMiddleEdge = yda;
-                    xLongestEdge = xdo; yLongestEdge = ydo;
 
                     shortestEdgeDist = aodist;
                     middleEdgeDist = dadist;
@@ -924,8 +910,6 @@ namespace TriangleNet
                     /// smallest angle corner: dest
                     /// largest angle corner: org
                     xShortestEdge = xao; yShortestEdge = yao;
-                    xMiddleEdge = xdo; yMiddleEdge = ydo;
-                    xLongestEdge = xda; yLongestEdge = yda;
 
                     shortestEdgeDist = aodist;
                     middleEdgeDist = dodist;
@@ -940,8 +924,6 @@ namespace TriangleNet
                     /// smallest angle corner: org
                     /// largest angle corner: apex
                     xShortestEdge = xda; yShortestEdge = yda;
-                    xMiddleEdge = xao; yMiddleEdge = yao;
-                    xLongestEdge = xdo; yLongestEdge = ydo;
 
                     shortestEdgeDist = dadist;
                     middleEdgeDist = aodist;
@@ -955,8 +937,6 @@ namespace TriangleNet
                     /// smallest angle corner: org
                     /// largest angle corner: dest
                     xShortestEdge = xda; yShortestEdge = yda;
-                    xMiddleEdge = xdo; yMiddleEdge = ydo;
-                    xLongestEdge = xao; yLongestEdge = yao;
 
                     shortestEdgeDist = dadist;
                     middleEdgeDist = dodist;
@@ -970,8 +950,6 @@ namespace TriangleNet
                     /// smallest angle corner: apex
                     /// largest angle corner: org
                     xShortestEdge = xdo; yShortestEdge = ydo;
-                    xMiddleEdge = xao; yMiddleEdge = yao;
-                    xLongestEdge = xda; yLongestEdge = yda;
 
                     shortestEdgeDist = dodist;
                     middleEdgeDist = aodist;
@@ -986,8 +964,6 @@ namespace TriangleNet
                     /// smallest angle corner: apex
                     /// largest angle corner: dest
                     xShortestEdge = xdo; yShortestEdge = ydo;
-                    xMiddleEdge = xda; yMiddleEdge = yda;
-                    xLongestEdge = xao; yLongestEdge = yao;
 
                     shortestEdgeDist = dodist;
                     middleEdgeDist = dadist;
@@ -3936,10 +3912,10 @@ namespace TriangleNet
             float dxod, dyod, dxda, dyda, dxao, dyao;
             float dxod2, dyod2, dxda2, dyda2, dxao2, dyao2;
 
-            float apexlen, orglen, destlen, minedge;
+            float apexlen, orglen, destlen;
             float angle;    // in order to check minimum angle condition 
 
-            float maxangle, maxedge;    // in order to check minimum angle condition
+            float maxangle;    // in order to check minimum angle condition
             // calculate the side lengths
 
             dxod = x1 - x2;
@@ -3964,8 +3940,6 @@ namespace TriangleNet
             // try to find the minimum edge and accordingly the pqr orientation
             if ((apexlen < orglen) && (apexlen < destlen))
             {
-                // The edge opposite the apex is shortest.
-                minedge = apexlen;
                 // Find the square of the cosine of the angle at the apex.
                 angle = dxda * dxao + dyda * dyao;
                 angle = angle * angle / (orglen * destlen);
@@ -3974,8 +3948,6 @@ namespace TriangleNet
             }
             else if (orglen < destlen)
             {
-                // The edge opposite the origin is shortest.
-                minedge = orglen;
                 // Find the square of the cosine of the angle at the origin.
                 angle = dxod * dxao + dyod * dyao;
                 angle = angle * angle / (apexlen * destlen);
@@ -3984,8 +3956,6 @@ namespace TriangleNet
             }
             else
             {
-                // The edge opposite the destination is shortest.
-                minedge = destlen;
                 // Find the square of the cosine of the angle at the destination.
                 angle = dxod * dxda + dyod * dyda;
                 angle = angle * angle / (apexlen * orglen);
@@ -3994,23 +3964,17 @@ namespace TriangleNet
             // try to find the maximum edge and accordingly the pqr orientation
             if ((apexlen > orglen) && (apexlen > destlen))
             {
-                // The edge opposite the apex is longest.
-                maxedge = apexlen;
                 // Find the cosine of the angle at the apex.
                 maxangle = (orglen + destlen - apexlen) / (2 * UnityEngine.Mathf.Sqrt(orglen * destlen));
             }
             else if (orglen > destlen)
             {
-                // The edge opposite the origin is longest.
-                maxedge = orglen;
                 // Find the cosine of the angle at the origin.
                 maxangle = (apexlen + destlen - orglen) / (2 * UnityEngine.Mathf.Sqrt(apexlen * destlen));
             }
             else
             {
-                // The edge opposite the destination is longest.
-                maxedge = destlen;
-                // Find the cosine of the angle at the destination.
+                 // Find the cosine of the angle at the destination.
                 maxangle = (apexlen + orglen - destlen) / (2 * UnityEngine.Mathf.Sqrt(apexlen * orglen));
             }
 

--- a/Assets/TriangleDotNet/Triangle/Primitives.cs
+++ b/Assets/TriangleDotNet/Triangle/Primitives.cs
@@ -154,7 +154,7 @@ namespace TriangleNet
         {
             Statistic.CounterClockwiseCountDecimal++;
 
-            decimal detleft, detright, det, detsum;
+            decimal detleft, detright, det;
 
             detleft = ((decimal)pa.x - (decimal)pc.x) * ((decimal)pb.y - (decimal)pc.y);
             detright = ((decimal)pa.y - (decimal)pc.y) * ((decimal)pb.x - (decimal)pc.x);
@@ -166,10 +166,7 @@ namespace TriangleNet
                 {
                     return det;
                 }
-                else
-                {
-                    detsum = detleft + detright;
-                }
+
             }
             else if (detleft < 0.0m)
             {
@@ -177,10 +174,7 @@ namespace TriangleNet
                 {
                     return det;
                 }
-                else
-                {
-                    detsum = -detleft - detright;
-                }
+
             }
 
             return det;

--- a/Assets/TriangleDotNet/Triangle/Quality.cs
+++ b/Assets/TriangleDotNet/Triangle/Quality.cs
@@ -25,9 +25,6 @@ namespace TriangleNet
 
         NewLocation newLocation;
 
-        // Not used at the moment
-        Func<Point, Point, Point, float, bool> userTest;
-
         ILog<SimpleLogItem> logger;
 
         public Quality(Mesh mesh)
@@ -438,16 +435,6 @@ namespace TriangleNet
                     // Add this triangle to the list of bad triangles.
                     queue.Enqueue(ref testtri, minedge, tapex, torg, tdest);
                     return;
-                }
-
-                // Check whether the user thinks this triangle is too large.
-                if (behavior.Usertest && userTest != null)
-                {
-                    if (userTest(torg, tdest, tapex, area))
-                    {
-                        queue.Enqueue(ref testtri, minedge, tapex, torg, tdest);
-                        return;
-                    }
                 }
             }
 

--- a/Assets/TriangleDotNet/Triangle/Tools/AdjacencyMatrix.cs
+++ b/Assets/TriangleDotNet/Triangle/Tools/AdjacencyMatrix.cs
@@ -19,9 +19,6 @@ namespace TriangleNet.Tools
         // Number of nodes in the mesh.
         int node_num;
 
-        // Number of adjacency entries.
-        int adj_num;
-
         // Pointers into the actual adjacency structure adj. Information about row k is
         // stored in entries adj_row(k) through adj_row(k+1)-1 of adj. Size: node_num + 1
         int[] adj_row;
@@ -42,14 +39,13 @@ namespace TriangleNet.Tools
 
         public AdjacencyMatrix(Mesh mesh)
         {
-            this.node_num = mesh.vertices.Count;
+            node_num = mesh.vertices.Count;
 
             // Set up the adj_row adjacency pointer array.
-            this.adj_row = AdjacencyCount(mesh);
-            this.adj_num = adj_row[node_num] - 1;
+            adj_row = AdjacencyCount(mesh);
 
             // Set up the adj adjacency array.
-            this.adj = AdjacencySet(mesh, this.adj_row);
+            adj = AdjacencySet(mesh, adj_row);
         }
 
         /// <summary>

--- a/Assets/TriangleDotNet/Triangle/Tools/RegionIterator.cs
+++ b/Assets/TriangleDotNet/Triangle/Tools/RegionIterator.cs
@@ -20,12 +20,10 @@ namespace TriangleNet.Tools
     /// </summary>
     public class RegionIterator
     {
-        Mesh mesh;
         List<Triangle> viri;
 
         public RegionIterator(Mesh mesh)
         {
-            this.mesh = mesh;
             this.viri = new List<Triangle>();
         }
 
@@ -49,8 +47,6 @@ namespace TriangleNet.Tools
             Otri testtri = default(Otri);
             Otri neighbor = default(Otri);
             Osub neighborsubseg = default(Osub);
-
-            Behavior behavior = mesh.behavior;
 
             // Loop through all the infected triangles, spreading the attribute
             // and/or area constraint to their neighbors, then to their neighbors'


### PR DESCRIPTION
I know you might not be maintaining this anymore, but I noticed these warnings whilst using your package - so thought I'd push the changes back. No functionality changes or fixes - just removing variables that are being assigned but not used.